### PR TITLE
Specify lts (long-term stable) version of node.js rather than latest stable version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
-node_js: node
+node_js: lts/*
 cache:
   bundler: true
   pip: true


### PR DESCRIPTION
See https://github.com/concord-consortium/collaborative-learning/pull/136 for detail.