### PR TITLE
Use easy-to-test CSS modules

### DIFF
--- a/cypress/integration/workspace.test.ts
+++ b/cypress/integration/workspace.test.ts
@@ -5,7 +5,7 @@ context("Test the overall app", () => {
 
   describe("Desktop functionalities", () => {
     it("renders with text", () => {
-      cy.get(".app").should("have.text", "Hello World");
+      cy.get(".app--app--__starter-projects-v1__").should("have.text", "Hello World");
     });
   });
 });

--- a/src/components/app.sass
+++ b/src/components/app.sass
@@ -1,4 +1,4 @@
-#app
+.app
   position: fixed
   top: 0
   left: 0

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -2,7 +2,7 @@ import { inject, observer } from "mobx-react";
 import * as React from "react";
 import { BaseComponent, IBaseProps } from "./base";
 
-import "./app.sass";
+import * as css from "./app.sass";
 
 interface IProps extends IBaseProps {}
 interface IState {}
@@ -14,7 +14,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
   public render() {
     const {ui} = this.stores;
     return (
-      <div className="app">
+      <div className={css.app}>
         {ui.sampleText}
       </div>
     );

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,2 @@
+// So we can import CSS modules.
+declare module "*.sass";

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,16 @@
     <meta name="description" content="Starter Projects">
     <link rel="shortcut icon" href="favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: 'Lato', sans-serif;
+        user-select: none;
+      }
+    </style>
   </head>
   <body>
     <svg aria-hidden="true" style="position: absolute; width: 0; height: 0; overflow: hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/src/index.sass
+++ b/src/index.sass
@@ -1,7 +1,0 @@
-html, body
-  margin: 0
-  padding: 0
-
-body
-  font-family: 'Lato', sans-serif;
-  user-select: none

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,8 +5,6 @@ import * as ReactDOM from "react-dom";
 import { AppComponent } from "./components/app";
 import { createStores } from "./models/stores";
 
-import "./index.sass";
-
 const stores = createStores({ });
 
 ReactDOM.render(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,15 @@ module.exports = (env, argv) => {
           test: /\.(sa|sc|c)ss$/i,
           use: [
             devMode ? 'style-loader' : MiniCssExtractPlugin.loader,
-            'css-loader',
+            {
+              loader: 'css-loader',
+              options: {
+                modules: true,
+                sourceMap: true,
+                importLoaders: 1,
+                localIdentName: '[name]--[local]--__starter-projects-v1__'
+              }
+            },
             'postcss-loader',
             'sass-loader'
           ]


### PR DESCRIPTION
I think that our main problem about CSS modules was that it's making integration testing really annoying because of the random hash.

This configuration setups **constant** prefix, which is still unique enough to be sure that we'll avoid 99.99% of conflicts with outer or inner apps/components.

It also makes testing possible, CSS classes are not pretty, but won't change randomly.  If we ever need to change this prefix, an update of tests will be trivial too.

Not pushing for it, this PR is opinionated and more like a proposal. But I think it gives us most of the CSS modules advantages and removes the major issue/pain. Does it seem like a reasonable compromise? 