### PR TITLE
Fix webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,12 +49,7 @@ module.exports = (env, argv) => {
           test: /\.(png|woff|woff2|eot|ttf|svg)$/,
           loader: 'url-loader',
           options: {
-            limit: 8192,
-            name: 'assets/[name].[ext]',
-            publicPath: function(url) {
-              // cf. https://github.com/webpack-contrib/file-loader/issues/160#issuecomment-349771544
-              return devMode ? url : url.replace(/assets/, '.');
-            }
+            limit: 8192
           }
         }
       ]
@@ -77,11 +72,7 @@ module.exports = (env, argv) => {
       }),
       new CopyWebpackPlugin([
         {from: 'src/public'}
-      ]),
-      new CopyWebpackPlugin([{
-        from: 'src/assets',
-        to: 'assets'
-      }])
+      ])
     ]
   };
 };


### PR DESCRIPTION
1. url-loader options: the previous config didn't work with code deployed to branches. Not sure what was the motivation behind these options, but I've never had any problems with any images/assets using the default configuration.
2. cop assets dir: I don't think we need two separate folders being directly copied to dist. I guess the only case is index.html using some images or favicons, but that can be placed directly in `public` dir. And `assets` can be used to keep there images loaded using webpack loaders (like url-loader). Easy to change later, but I'd start with simpler approach.