### PR TITLE
Remove cloudfront invalidation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
 - pyenv local 3.6
 install:
 - travis_retry gem install s3_website -v 3.4.0
-- travis_retry pip install awscli --upgrade --user
 - travis_retry npm ci
 - travis_retry cypress install
 script:

--- a/s3_deploy.sh
+++ b/s3_deploy.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 SRC_DIR='dist'
-DISTRIBUTION_ID='E1YPVV3YLYS4J7'
 # name of branch to deploy to root of site
 PRODUCTION_BRANCH='production'
 
@@ -29,21 +28,17 @@ if [ "$TRAVIS_BRANCH" = "$CURRENT_TAG" ]; then
   mkdir -p _site/version
   S3_DEPLOY_DIR="version/$TRAVIS_BRANCH"
   DEPLOY_DEST="_site/$S3_DEPLOY_DIR"
-  INVAL_PATH="/version/$TRAVIS_BRANCH/index.html"
   # used by s3_website.yml
   export S3_DEPLOY_DIR
 
 # production branch builds deploy to root of site
 elif [ "$TRAVIS_BRANCH" = "$PRODUCTION_BRANCH" ]; then
   DEPLOY_DEST="_site"
-  INVAL_PATH="/index.html"
-
 # branch builds deploy to /branch/BRANCH_NAME
 else
   mkdir -p _site/branch
   S3_DEPLOY_DIR="branch/$DEPLOY_DIR_NAME"
   DEPLOY_DEST="_site/$S3_DEPLOY_DIR"
-  INVAL_PATH="/branch/$DEPLOY_DIR_NAME/index.html"
   # used by s3_website.yml
   export S3_DEPLOY_DIR
 fi
@@ -53,7 +48,3 @@ mv $SRC_DIR $DEPLOY_DEST
 
 # deploy the site contents
 s3_website push --site _site
-
-# explicit CloudFront invalidation to workaround s3_website gem invalidation bug
-# with origin path (https://github.com/laurilehmijoki/s3_website/issues/207).
-aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths $INVAL_PATH

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -3,10 +3,6 @@ s3_key_prefix: starter-projects
 s3_endpoint: us-east-1
 gzip: true
 
-cloudfront_distribution_id: E1YPVV3YLYS4J7
-cloudfront_invalidate_root: true
-cloudfront_wildcard_invalidation: true
-
 <% if ENV['TRAVIS_BRANCH'] == 'production' %>
 # in this case we are going to deploy this branch to the top level of the domain
 # so we need to ignore the version and branch folders
@@ -21,9 +17,3 @@ max_age:
   "starter-projects/*": 600 # 10 minutes
   "starter-projects/version/*": 31536000 # 1 year
   "starter-projects/branch/*": 0
-
-cloudfront_distribution_config:
-  aliases:
-    quantity: 1
-    items:
-      - starter-projects.concord.org


### PR DESCRIPTION
@scytacki recommended not to use it. s3_website implementation is probably buggy, and there's still browser cache, so it seems better to use reasonable cache headers instead. 