### PR TITLE
Add text translation capabilities

### DIFF
--- a/src/hooks/use-sample-text.ts
+++ b/src/hooks/use-sample-text.ts
@@ -1,8 +1,9 @@
 import { useState } from "react";
+import t from "../utils/translation/translate";
 
 export const useSampleText = () => {
   // `useState` is unnecessary here. But it's used, so this function works like a real hook and requires special testing.
   // If this function was only returning "Hello World", we wouldn't need any special approach to testing.
-  const [ text ] = useState("Hello World");
+  const [ text ] = useState(t("INTRO.HELLO"));
   return text;
 };

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
     <meta charset="UTF-8">
     <title>Starter Projects</title>

--- a/src/utils/translation/README.md
+++ b/src/utils/translation/README.md
@@ -1,0 +1,45 @@
+# Starter Projects Translation Functions
+
+The modules within `utils/translation` can be used to add text translation to a starter-projects based application.
+
+### How to use
+
+#### Adding translation files
+
+Translation JSON files are added to `utils/translation/lang`.  Add a translation JSON file for each translated language and import the translation JSON file in `utils/translation/translate.ts`.  Name the translation JSON file using the ISO 639-1 Language Code for the given language (i.e., `fr.json` for French or `de.json` for German).  Add a key/value pair for each translated word or phrase.  The key is used by the translation function and the value is the actual translated text.
+```
+{
+  "TEXT": "text",
+  "INTRO.HELLO": "Hello World"
+}
+```
+
+#### Using the translation function
+
+Import the `translate` function found in `utils/translation/translate.ts` in your module:
+```
+import t from "../utils/translation/translate";
+```
+
+Call the function using the translation key of the desired text:
+```
+console.log(t("INTRO.HELLO"));
+```
+
+Variables can be defined and specified in your translated text.  Use the format `%{VAR_NAME}` to add a variable to a key's value in the translation JSON file:
+```
+{
+  "AGE": "I am %{userAge} years old"
+}
+```
+Use the `vars` property of the `options` parameter to specify one or more variable values when calling the translation function:
+```
+console.log(t("AGE", { vars: { userAge: "25" } }));
+```
+
+
+#### Determining the current language
+The `translate` function will first get the HTML DOM `lang` attribute of the root element of the document to determine the current page language.  If no `lang` attribute is specified, then the `translate` function will get the first valid language specified by the browser to detgermine the current page language.  Optionally, a language value can be specified when calling the `translate` function that will override the `lang` attribute and the browser settings.  Use the `lang` property of the `options` parameter to specify a language when calling the `translate` function:
+```
+console.log(t("INTRO.HELLO", { lang: "es" }));
+```

--- a/src/utils/translation/README.md
+++ b/src/utils/translation/README.md
@@ -1,6 +1,6 @@
-# Starter Projects Translation Functions
+# Starter Projects Localization
 
-The modules within `utils/translation` can be used to add text translation to a starter-projects based application.
+The modules within `utils/translation` can be used to add text localization to a starter-projects based application.
 
 ### How to use
 
@@ -14,7 +14,7 @@ Translation JSON files are added to `utils/translation/lang`.  Add a translation
 }
 ```
 
-#### Using the translation function
+#### Using the translate function
 
 Import the `translate` function found in `utils/translation/translate.ts` in your module:
 ```
@@ -39,7 +39,7 @@ console.log(t("AGE", { vars: { userAge: "25" } }));
 
 
 #### Determining the current language
-The `translate` function will first get the HTML DOM `lang` attribute of the root element of the document to determine the current page language.  If no `lang` attribute is specified, then the `translate` function will get the first valid language specified by the browser to detgermine the current page language.  Optionally, a language value can be specified when calling the `translate` function that will override the `lang` attribute and the browser settings.  Use the `lang` property of the `options` parameter to specify a language when calling the `translate` function:
+The `translate` function will first get the HTML DOM `lang` attribute of the root element of the document to determine the current page language.  If no `lang` attribute is specified, then the `translate` function will get the first valid language specified by the browser to determine the current page language.  Optionally, a language value can be specified when calling the `translate` function that will override the `lang` attribute and the browser settings.  Use the `lang` property of the `options` parameter to specify a language when calling the `translate` function:
 ```
 console.log(t("INTRO.HELLO", { lang: "es" }));
 ```

--- a/src/utils/translation/lang/en-us.json
+++ b/src/utils/translation/lang/en-us.json
@@ -1,4 +1,4 @@
 {
-  "~TEXT": "text",
-  "~INTRO.HELLO": "Hello World"
+  "TEXT": "text",
+  "INTRO.HELLO": "Hello World"
 }

--- a/src/utils/translation/lang/en-us.json
+++ b/src/utils/translation/lang/en-us.json
@@ -1,0 +1,4 @@
+{
+  "~TEXT": "text",
+  "~INTRO.HELLO": "Hello World"
+}

--- a/src/utils/translation/lang/es.json
+++ b/src/utils/translation/lang/es.json
@@ -1,4 +1,4 @@
 {
-  "~TEXT": "texto",
-  "~INTRO.HELLO": "Hola Mundo"
+  "TEXT": "texto",
+  "INTRO.HELLO": "Hola Mundo"
 }

--- a/src/utils/translation/lang/es.json
+++ b/src/utils/translation/lang/es.json
@@ -1,0 +1,4 @@
+{
+  "~TEXT": "texto",
+  "~INTRO.HELLO": "Hola Mundo"
+}

--- a/src/utils/translation/translate.ts
+++ b/src/utils/translation/translate.ts
@@ -40,16 +40,25 @@ languageFiles.forEach((langFile) => {
   }
 });
 
-const lang = getPageLanguage() || getFirstBrowserLanguage();
-const baseLang = getBaseLanguage(lang || "");
-const defaultLang = lang && translations[lang]
-                    ? lang
+const varRegExp = /%\{\s*([^}\s]*)\s*\}/g;
+
+const currentLang = getPageLanguage() || getFirstBrowserLanguage();
+const baseLang = getBaseLanguage(currentLang || "");
+const defaultLang = currentLang && translations[currentLang]
+                    ? currentLang
                     : baseLang && translations[baseLang]
                       ? baseLang
                       : "en";
 
-const translate = (key: string) => {
-  return translations[defaultLang][key] || `UNKNOWN KEY: ${key}`;
+const translate = (key: string, vars: any = {}, lang: string = defaultLang) => {
+  const translation = translations?.[lang]?.[key] || key;
+  return translation.replace(varRegExp, (match: string, langKey: string) => {
+    if (Object.prototype.hasOwnProperty.call(vars, langKey)) {
+      return vars[langKey];
+    } else {
+      return `'** UNKNOWN KEY: ${langKey} **`;
+    }
+  });
 };
 
 export default translate;

--- a/src/utils/translation/translate.ts
+++ b/src/utils/translation/translate.ts
@@ -1,8 +1,3 @@
-// To use, build translation JSON files, import translate function, and call with translation key:
-// import t from "../utils/translation/translate";
-// console.log(t("INTRO.HELLO"));
-// Otherwise, add lang attribute to index.html if language is static (i.e., <html lang="en">)
-
 import enUS from "./lang/en-us.json";
 import es from "./lang/es.json";
 
@@ -52,7 +47,15 @@ const defaultLang = currentLang && translations[currentLang]
                       ? baseLang
                       : "en";
 
-const translate = (key: string, vars: Record<string, string> = {}, lang = defaultLang) => {
+interface ITranslateOptions {
+  lang?: string;
+  count?: number;
+  vars?: Record<string, string>;
+}
+
+export default function translate (key: string, options?: ITranslateOptions) {
+  const lang = options?.lang || defaultLang;
+  const vars = options?.vars || {};
   const translation = translations?.[lang]?.[key] || key;
   return translation.replace(varRegExp, (match: string, langKey: string) => {
     if (Object.prototype.hasOwnProperty.call(vars, langKey)) {
@@ -61,6 +64,4 @@ const translate = (key: string, vars: Record<string, string> = {}, lang = defaul
       return `'** UNKNOWN KEY: ${langKey} **`;
     }
   });
-};
-
-export default translate;
+}

--- a/src/utils/translation/translate.ts
+++ b/src/utils/translation/translate.ts
@@ -1,0 +1,55 @@
+// To use, remove lang attribute from index.html, import translate function, and call with translation key:
+// translate("~INTRO.HELLO")
+
+import enUS from "./lang/en-us.json";
+import es from "./lang/es.json";
+
+const languageFiles = [
+  {key: "en-US", contents: enUS},   // US English
+  {key: "es",    contents: es},     // Spanish
+];
+
+// returns baseLANG from baseLANG-REGION if REGION exists
+// this will, for example, convert en-US to en
+const getBaseLanguage = (langKey: any) => {
+  return langKey.split("-")[0];
+};
+
+// Get the HTML DOM lang property of the root element of the document
+const getPageLanguage = () => {
+  const pageLang = document.documentElement.lang;
+  return pageLang && (pageLang !== "unknown") ? pageLang : undefined;
+};
+
+// Get the first valid language specified by the browser
+const getFirstBrowserLanguage = () => {
+  const nav: any = window.navigator;
+  // userLanguage and browserLanguage are non standard but required for IE support
+  const languages = [...nav.languages, nav.language, nav.userLanguage, nav.browserLanguage];
+  return languages.find((browserLang) => browserLang);
+};
+
+const translations: any = {};
+
+languageFiles.forEach((langFile) => {
+  translations[langFile.key] = langFile.contents;
+  // accept full key with region code or just the language code
+  const bLang = getBaseLanguage(langFile.key);
+  if (bLang && !translations[bLang]) {
+    translations[bLang] = langFile.contents;
+  }
+});
+
+const lang = getPageLanguage() || getFirstBrowserLanguage();
+const baseLang = getBaseLanguage(lang || "");
+const defaultLang = lang && translations[lang]
+                    ? lang
+                    : baseLang && translations[baseLang]
+                      ? baseLang
+                      : "en";
+
+const translate = (key: string) => {
+  return translations[defaultLang][key] || `UNKNOWN KEY: ${key}`;
+};
+
+export default translate;

--- a/src/utils/translation/translate.ts
+++ b/src/utils/translation/translate.ts
@@ -1,5 +1,7 @@
-// To use, remove lang attribute from index.html, import translate function, and call with translation key:
-// translate("~INTRO.HELLO")
+// To use, build translation JSON files, import translate function, and call with translation key:
+// import t from "../utils/translation/translate";
+// console.log(t("INTRO.HELLO"));
+// Otherwise, add lang attribute to index.html if language is static (i.e., <html lang="en">)
 
 import enUS from "./lang/en-us.json";
 import es from "./lang/es.json";
@@ -50,7 +52,7 @@ const defaultLang = currentLang && translations[currentLang]
                       ? baseLang
                       : "en";
 
-const translate = (key: string, vars: any = {}, lang: string = defaultLang) => {
+const translate = (key: string, vars: Record<string, string> = {}, lang = defaultLang) => {
   const translation = translations?.[lang]?.[key] || key;
   return translation.replace(varRegExp, (match: string, langKey: string) => {
     if (Object.prototype.hasOwnProperty.call(vars, langKey)) {


### PR DESCRIPTION
This PR adds a text translation mechanism to the starter-projects.  It is heavily based upon the CFM translation model seen here:
https://github.com/concord-consortium/cloud-file-manager/blob/master/src/code/utils/translate.js

I tested this in Chrome, Firefox, Edge, Safari.  Works well in all cases by both changing the lang property in `index.html` or by changing the browser settings.

Notes on implementation:
- translation json files are added to `utils/lang`
- translation is handled in `utils/lang/translate.ts` and can be added by importing the `translate` function and calling the function with the appropriate translation key:
`t("INTRO.HELLO")`
- ~~I'm not crazy about the translation keys using a tilde, but this was the approach used in the CFM, and I wanted to be consistent. Also it makes it much easier to search for text keys.  Does anyone have an opinion on this?~~
**EDIT**: I changed the code and removed the tilde
- by default we choose the language by first looking at the HTML DOM lang property of the root element of the document and then by looking at first valid language specified by the browser.  This is the technique used by the CFM, and I think it is fine as long as we know to remove/update/change the `lang="en"` attribute from `index.html`.  I'm also open to switching the check and looking at the browser specified language *first*.  
**EDIT**: I think we should leave the checks as is but remove the lang property in `index.html` so that the translation works out of the box by changing browser settings.
- ~~I made the decision to remove a couple of the optional parameters (`vars`, `lang`) that were used in the CFM `translate` function seen here:
https://github.com/concord-consortium/cloud-file-manager/blob/master/src/code/utils/translate.js#L77
I'm open to bringing these params back, but it seemed that they added extra complexity to a function that at least for a base implementation should be fairly simple.  Thoughts?~~
**EDIT**: I added all of the parameters seen in the CFM function.
- ~~I chose not to translate the intro "Hello World" text that is first displayed in the app.  I don't want users of the starter-projects to feel as if the translation is a tool that *needs* to be used, but rather a lightweight option that is there by default which can be used, left for future use, or removed.~~
**EDIT**: the intro hello world text is now wrapped in the translation function.  Users of the starter-projects can remove the translation if they don't want it, but it is in use by default.