### PR TITLE
support configured buckets, and root of bucket deploys

### DIFF
--- a/s3_deploy.sh
+++ b/s3_deploy.sh
@@ -26,7 +26,7 @@ trap 'echo "\"${last_command}\" command exited with code $?."' EXIT
 
 # extract current TAG if present
 # the 2> is to prevent error messages when no match is found
-# the \\ echo prevents script exit when it doesn't match
+# the || echo prevents script exit when it doesn't match
 CURRENT_TAG=`git describe --tags --exact-match $GITHUB_SHA 2> /dev/null || echo ''`
 
 # Extract the branch or tag name from the GITHUB_REF

--- a/s3_deploy.sh
+++ b/s3_deploy.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+# Typically this is the Project name.
+# The trailing slash is important
+# Can be set to an empty string for working at the top level of the bucket
+S3_BUCKET_PREFIX='starter-projects/'
+# AWS CloudFront distribution ID
+DISTRIBUTION_ID='E1YPVV3YLYS4J7'
+# AWS CloudFront distribution domain
+DISTRIBUTION_DOMAIN='starter-projects.concord.org'
+# name of branch to deploy to root of site
+ROOT_BRANCH='production'
+# Bucket to deploy to, typically this is 'model-resourcs', but some projects
+# have their own buckets
+S3_BUCKET='models-resources'
+# location of built files
+SRC_DIR='dist'
+
 # exit when any command fails
 set -e
 
@@ -7,17 +23,6 @@ set -e
 trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
 # echo an error message before exiting
 trap 'echo "\"${last_command}\" command exited with code $?."' EXIT
-
-# Project Name used as folder in S3 bucket
-PROJECT_NAME='starter-projects'
-# AWS CloudFront distribution ID
-DISTRIBUTION_ID='E1YPVV3YLYS4J7'
-# AWS CloudFront distribution domain
-DISTRIBUTION_DOMAIN='starter-projects.concord.org'
-# name of branch to deploy to root of site
-ROOT_BRANCH='production'
-# location of built files
-SRC_DIR='dist'
 
 # extract current TAG if present
 # the 2> is to prevent error messages when no match is found
@@ -53,7 +58,7 @@ if [ "$BRANCH_OR_TAG" = "$CURRENT_TAG" ]; then
   # So ignore everything except this folder.
   # Currently this only escapes `.`
   S3_DEPLOY_DIR_ESCAPED=$(sed 's/[.]/[&]/g;' <<<"$S3_DEPLOY_DIR")
-  IGNORE_ON_SERVER="^(?!$PROJECT_NAME/$S3_DEPLOY_DIR_ESCAPED/)"
+  IGNORE_ON_SERVER="^(?!$S3_BUCKET_PREFIX$S3_DEPLOY_DIR_ESCAPED/)"
 
 # root branch builds deploy to root of site
 elif [ "$BRANCH_OR_TAG" = "$ROOT_BRANCH" ]; then
@@ -61,7 +66,7 @@ elif [ "$BRANCH_OR_TAG" = "$ROOT_BRANCH" ]; then
   INVAL_PATH="/index.html"
   # in this case we are going to deploy this branch to the top level
   # so we need to ignore the version and branch folders
-  IGNORE_ON_SERVER="^$PROJECT_NAME/(version/|branch/)"
+  IGNORE_ON_SERVER="^$S3_BUCKET_PREFIX(version/|branch/)"
 
 # branch builds deploy to /branch/BRANCH_NAME
 else
@@ -73,20 +78,21 @@ else
   # So ignore everything except this folder.
   # Currently this only escapes `.`
   S3_DEPLOY_DIR_ESCAPED=$(sed 's/[.]/[&]/g;' <<<"$S3_DEPLOY_DIR")
-  IGNORE_ON_SERVER="^(?!$PROJECT_NAME/$S3_DEPLOY_DIR_ESCAPED/)"
+  IGNORE_ON_SERVER="^(?!$S3_BUCKET_PREFIX$S3_DEPLOY_DIR_ESCAPED/)"
 fi
 
 # used by s3_website.yml
-export PROJECT_NAME
+export S3_BUCKET_PREFIX
 export IGNORE_ON_SERVER
 export DISTRIBUTION_ID
 export DISTRIBUTION_DOMAIN
+export S3_BUCKET
 
 # copy files to destination
 mv $SRC_DIR $DEPLOY_DEST
 
 # deploy the site contents
-echo Deploying "$BRANCH_OR_TAG" to "$PROJECT_NAME/$S3_DEPLOY_DIR"...
+echo Deploying "$BRANCH_OR_TAG" to "$S3_BUCKET:$S3_BUCKET_PREFIX$S3_DEPLOY_DIR"...
 s3_website push --site _site
 
 # explicit CloudFront invalidation to workaround s3_website gem invalidation bug

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -1,9 +1,10 @@
 s3_bucket: <%= ENV['S3_BUCKET'] %>
+# only add the s3_key_prefix if there is one
+<% if ENV['S3_BUCKET_PREFIX'] != '' %>
 # Everywhere else the s3 prefix needs a trailing slash
-# However s3_website config need one
-# double backslash `\\` is needed for erb escaping
+# However s3_website config doesn't need one
 s3_key_prefix: <%= ENV['S3_BUCKET_PREFIX'].sub(/\\/$/, '') %>
-s3_endpoint: us-east-1
+<% end %>s3_endpoint: us-east-1
 gzip: true
 
 cloudfront_distribution_id: <%= ENV['DISTRIBUTION_ID'] %>

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -1,7 +1,8 @@
 s3_bucket: <%= ENV['S3_BUCKET'] %>
 # Everywhere else the s3 prefix needs a trailing slash
 # However s3_website config need one
-s3_key_prefix: <%= ENV['S3_BUCKET_PREFIX'].sub(/\/$/, '') %>
+# double backslash `\\` is needed for erb escaping
+s3_key_prefix: <%= ENV['S3_BUCKET_PREFIX'].sub(/\\/$/, '') %>
 s3_endpoint: us-east-1
 gzip: true
 

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -4,7 +4,8 @@ s3_bucket: <%= ENV['S3_BUCKET'] %>
 # Everywhere else the s3 prefix needs a trailing slash
 # However s3_website config doesn't need one
 s3_key_prefix: <%= ENV['S3_BUCKET_PREFIX'].sub(/\\/$/, '') %>
-<% end %>s3_endpoint: us-east-1
+<% end %>
+s3_endpoint: us-east-1
 gzip: true
 
 cloudfront_distribution_id: <%= ENV['DISTRIBUTION_ID'] %>

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -1,4 +1,4 @@
-s3_bucket: <%= ENV['S3_BUCKET'] $>
+s3_bucket: <%= ENV['S3_BUCKET'] %>
 # Everywhere else the s3 prefix needs a trailing slash
 # However s3_website config need one
 s3_key_prefix: <%= ENV['S3_BUCKET_PREFIX'].sub(/\/$/, '') %>

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -1,5 +1,7 @@
-s3_bucket: models-resources
-s3_key_prefix: <%= ENV['PROJECT_NAME'] %>
+s3_bucket: <%= ENV['S3_BUCKET'] $>
+# Everywhere else the s3 prefix needs a trailing slash
+# However s3_website config need one
+s3_key_prefix: <%= ENV['S3_BUCKET_PREFIX'].sub(/\/$/, '') %>
 s3_endpoint: us-east-1
 gzip: true
 
@@ -9,9 +11,9 @@ cloudfront_wildcard_invalidation: true
 
 ignore_on_server: <%= ENV['IGNORE_ON_SERVER'] %>
 max_age:
-  "<%= ENV['PROJECT_NAME'] %>/*": 600 # 10 minutes
-  "<%= ENV['PROJECT_NAME'] %>/version/*": 31536000 # 1 year
-  "<%= ENV['PROJECT_NAME'] %>/branch/*": 0
+  "<%= ENV['S3_BUCKET_PREFIX'] %>*": 600 # 10 minutes
+  "<%= ENV['S3_BUCKET_PREFIX'] %>version/*": 31536000 # 1 year
+  "<%= ENV['S3_BUCKET_PREFIX'] %>branch/*": 0
 
 cloudfront_distribution_config:
   aliases:


### PR DESCRIPTION
These changes are necessary to support the portal-report repository. 
I think we also have some other legacy repositories that deploy to the root of a custom bucket.