### PR TITLE
Record the jest coverage into codecov.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
         run: npm run build
       - name: Run Tests
         run: npm run test:coverage -- --runInBand
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          flags: jest
   cypress:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
You can see the basic info here: https://codecov.io/gh/concord-consortium/starter-projects/branch/add-codecov-of-jest
Once this is merged to master then PRs show difference in coverage from master.