### PR TITLE
add demo of running 3 cypress jobs in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,15 @@ jobs:
           flags: jest
   cypress:
     runs-on: ubuntu-latest
+    strategy:
+      # when one test fails, DO NOT cancel the other
+      # containers, because this will kill Cypress processes
+      # leaving the Dashboard hanging ...
+      # https://github.com/cypress-io/github-action/issues/48
+      fail-fast: false
+      matrix:
+        # run 3 copies of the current job in parallel
+        containers: [1, 2, 3]
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -30,6 +39,8 @@ jobs:
           wait-on: 'http://localhost:8080'
           # only record the results to dashboard.cypress.io if CYPRESS_RECORD_KEY is set
           record: ${{ !!secrets.CYPRESS_RECORD_KEY }}
+          # only do parallel if we have a record key
+          parallel: ${{ !!secrets.CYPRESS_RECORD_KEY }}
         env:
           # pass the Dashboard record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}


### PR DESCRIPTION
In this project it won't have any effect on the cypress run time, but once there are
more test this will have a major effect.

You can see the difference in these two builds of the portal-report:
before parallel
https://github.com/concord-consortium/portal-report/actions/runs/377948181
runtime: 10:38

after parallel
https://github.com/concord-consortium/portal-report/actions/runs/377950963
runtime: 6:45

The cypress dashboard provides an estimate of how the time changes with different number of jobs:
https://dashboard.cypress.io/projects/er5qci/runs/1056/specs
click the 'see full analysis' button on that page.