### PR TITLE
Explicitly use ubuntu-18.04 since ubunutu-latest is now 20.04 and it doesn't have the right java version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
-      - name: Setup Ruby 2.4
+      - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.4'
+          ruby-version: '2.7'
       - name: Install Dependencies
         run: |
           gem install s3_website -v 3.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     needs:
       - build_test
       - cypress
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1


### PR DESCRIPTION
This also bumps the ruby version 2.7 for good measure since 2.4 is no longer supported.