### PR TITLE
Update GitHub actions configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
       - name: Install Dependencies
         run: npm ci
       - name: Build
@@ -32,7 +32,7 @@ jobs:
         containers: [1, 2, 3]
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - uses: cypress-io/github-action@v2
         with:
           start: npm start
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:

--- a/s3_deploy.sh
+++ b/s3_deploy.sh
@@ -91,9 +91,9 @@ export S3_BUCKET
 # copy files to destination
 mv $SRC_DIR $DEPLOY_DEST
 
-# deploy the site contents
+# deploy the site contents; increase memory for s3_website gem
 echo Deploying "$BRANCH_OR_TAG" to "$S3_BUCKET:$S3_BUCKET_PREFIX$S3_DEPLOY_DIR"...
-s3_website push --site _site
+JAVA_TOOL_OPTIONS="-Xms1g -Xmx2g" s3_website push --site _site
 
 # explicit CloudFront invalidation to workaround s3_website gem invalidation bug
 # with origin path (https://github.com/laurilehmijoki/s3_website/issues/207).


### PR DESCRIPTION
- update to `actions/setup-node@v2` (corresponds to node 14, while v1 corresponds to node 10)
- update to `actions/checkout@v2` (for consistency with other `actions/checkout` instances in the same file)
- increase memory for `s3_website` gem for copying larger applications