### PR TITLE
add the concord.png image

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Text } from "./text";
 import { useSampleText } from "../hooks/use-sample-text";
+import Icon from "../assets/concord.png";
 
 import "./app.scss";
 
@@ -8,8 +9,8 @@ export const App = () => {
   const sampleText = useSampleText();
   return (
     <div className="app">
+      <img src={Icon}/>
       <Text text={sampleText} />
     </div>
   );
 };
-

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,1 +1,2 @@
+declare module "*.png";
 declare module "*.svg";


### PR DESCRIPTION
This forces the typescript global config for *.png
It also demonstrates how to use webpack to reference assets instead of
hardcoded references.