### PR TITLE
remove CopyWebpackPlugin, switch to favicon config

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <title>Starter Projects</title>
     <meta name="description" content="Starter Projects">
-    <link rel="shortcut icon" href="favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
   </head>
   <body>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@
 const path = require('path');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 module.exports = (env, argv) => {
@@ -123,12 +122,8 @@ module.exports = (env, argv) => {
       }),
       new HtmlWebpackPlugin({
         filename: 'index.html',
-        template: 'src/index.html'
-      }),
-      new CopyWebpackPlugin({
-        patterns: [
-          { from: 'src/public' },
-        ],
+        template: 'src/index.html',
+        favicon: 'src/public/favicon.ico'
       }),
       new CleanWebpackPlugin(),
     ]


### PR DESCRIPTION
Using CopyWebpackPlugin encourages direct or hardcoded asset paths in the code,
These hardcoded assets paths reduce the portability of the generated javascript.

HtmlWebpackPlugin provides a favicon config which automatically copies the icon

We were also including a "shortcut" rel identifier in our `<link>` tag, the
HtmlWebpackPlugin does not generate this shorcut rel. According MDN we should
not be using shortcut anymore:
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#values:~:text=respectively.-,The%20shortcut%20link%20type%20is%20often%20seen%20before%20icon%2C%20but%20this%20link%20type%20is%20non%2Dconforming%2C%20ignored%20and%20web,authors%20must%20not%20use%20it%20anymore.,-alternate