### PR TITLE
Update SVGR config so it doesn't remove viewBox from imported SVGs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -105,6 +105,8 @@ module.exports = (env, argv) => {
                           // leave "stroke"s and "fill"s alone
                           // https://github.com/svg/svgo/blob/master/plugins/removeUnknownsAndDefaults.js
                           removeUnknownsAndDefaults: { defaultAttrs: false },
+                          // leave viewBox alone
+                          removeViewBox: false
                         }
                       }
                     }


### PR DESCRIPTION
It was useful in Tectonic Explorer (https://github.com/concord-consortium/tectonic-explorer/pull/172) and it seems safer in general.

@kswenson suggested adding this option to multiple of our repos. I'm opening PR only here - I won't do in other projects that I don't actively work on as I wouldn't have a way to test these changes. Also, if things work fine there, maybe we shouldn't touch it. 😉 