### PR TITLE
Update release.yml, index-demo -> index

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,13 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: The git tag for the version to use for index-demo.html
+        description: The git tag for the version to use for index.html
         required: true
 env:
   BUCKET: models-resources
   PREFIX: starter-projects
   SRC_FILE: index-top.html
-  DEST_FILE: index-demo.html
+  DEST_FILE: index.html
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I've been using this template quite a lot and multiple repos ended up with index-demo release which is not what we wanted there. :wink: Can we change it to index.html here, or is there any reason for keeping index-demo.html?