### PR TITLE
add a deployment URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
       - build_test
       - cypress
     runs-on: ubuntu-latest
+    environment:
+      # The name cannot 
+      name: development
+      url: https://models-resources.concord.org/starter-projects/${{ steps.s3-deploy.outputs.deployPath }}/index.html
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -74,6 +78,7 @@ jobs:
           # This decreases the deploy time quite a bit
           CYPRESS_INSTALL_BINARY: 0
       - uses: concord-consortium/s3-deploy-action@v1
+        id: s3-deploy
         with:
           bucket: models-resources
           prefix: starter-projects

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,7 @@ jobs:
       - cypress
     runs-on: ubuntu-latest
     environment:
-      # The name cannot 
-      name: development
+      name: ${{ github.ref_type == 'branch' && 'branches' || 'versions' }}
       url: https://models-resources.concord.org/starter-projects/${{ steps.s3-deploy.outputs.deployPath }}/index.html
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Adding this config to the GitHub action tells GitHub to record the s3 deployment. You can see the deployment in the PR with the `view deployment` buttons.  And at the bottom is a section "This branch was successfully deployed".

Also all of the deployments are recorded here: https://github.com/concord-consortium/starter-projects/deployments

The environment name is set based on the ref type. This will make it easier to see our version deployments compared to our branch deployments. 

The environment name cannot be computed from the job outputs, so we can't use the output of the s3-deployaction here. This [restriction](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idenvironment) is because the environment name can determine which secrets the job has access to, so those have to determined before the job runs.

However we were able construct an expression using the `github.ref_type` [variable](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) which can check if the build is a branch or a tag.
