### PR TITLE
Rename master to main, upgrade GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,10 @@ jobs:
       - name: Run Tests
         run: npm run test:coverage -- --runInBand
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
           flags: jest
+          token: ${{ secrets.CODECOV_TOKEN }}
   cypress:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     name: Build and Run Jest Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
       - name: Install Dependencies
         run: npm ci
       - name: Build
@@ -32,8 +32,8 @@ jobs:
         containers: [1, 2, 3]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: cypress-io/github-action@v4
+        uses: actions/checkout@v4
+      - uses: cypress-io/github-action@v6
         with:
           start: npm start
           wait-on: 'http://localhost:8080'
@@ -55,9 +55,10 @@ jobs:
           # by default.
           CYPRESS_coverage: true
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
           flags: cypress
+          token: ${{ secrets.CODECOV_TOKEN }}
   s3-deploy:
     name: S3 Deploy
     needs:
@@ -68,8 +69,8 @@ jobs:
       name: ${{ github.ref_type == 'branch' && 'branches' || 'versions' }}
       url: https://models-resources.concord.org/starter-projects/${{ steps.s3-deploy.outputs.deployPath }}/index.html
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
       - name: Install Dependencies
         run: npm ci
         env:
@@ -86,4 +87,4 @@ jobs:
           # Parameters to GHActions have to be strings, so a regular yaml array cannot
           # be used. Instead the `|` turns the following lines into a string
           topBranches: |
-            ["master"]
+            ["main"]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 6. Push to your new repository
     ```
     git remote add origin https://github.com/concord-consortium/new-repository.git
-    git push -u origin master
+    git push -u origin main
     ```
 7. Open your new repository and update all instances of `starter-projects` to `new-repository` and `Starter Projects` to `New Repository`.
    Note: this will do some of the configuration for GitHub Actions deployment to S3, but you'll still need to follow
@@ -48,10 +48,15 @@
    - go to https://dashboard.cypress.io
    - create a new project
    - go to the settings for the project
-   - in the github integration section choose the github repo to connect this project to
-   - copy the record key, and create a secret in the github repositories settings with the name CYPRESS_RECORD_KEY
+   - in the GitHub integration section choose the GitHub repo to connect this project to
+   - copy the record key, and create a secret in the GitHub repository's settings with the name CYPRESS_RECORD_KEY
    - copy the Project ID and replace the value of `projectId` in cypress.json
-9. Your new repository is ready! Remove this section of the `README`, and follow the steps below to use it.
+9. To record code coverage information to codecov.io:
+   - go to https://codecov.io/
+   - login with your GitHub credentials
+   - find your new repository
+   - go to the settings for this repository and copy the CODECOV_TOKEN, and create a secret in the GitHub repository's settings.
+10. Your new repository is ready! Remove this section of the `README`, and follow the steps below to use it.
 
 ### Initial steps
 
@@ -89,7 +94,7 @@ You *do not* need to build to deploy the code, that is automatic.  See more info
 
 Follow the instructions in this
 [Guide](https://docs.google.com/document/d/1EacCSUhaHXaL8ll8xjcd4svyguEO-ipf5aF980-_q8E)
-to setup an S3 & Cloudfront distribution that can be used with Github actions.
+to setup an S3 & Cloudfront distribution that can be used with GitHub actions.
 See also `s3_deploy.sh`, and `./github/ci.yml`.
 
 Production releases to S3 are based on the contents of the /dist folder and are built automatically by GitHub Actions
@@ -108,14 +113,14 @@ To deploy a production release:
 4. Run `npm run build`
 5. Copy asset size markdown table from previous release and change sizes to match new sizes in `dist`
 6. Create `release-<version>` branch and commit changes, push to GitHub, create PR and merge
-7. Checkout master and pull
+7. Checkout main and pull
 8. Create an annotated tag for the version, of the form `v[x].[y].[z]`, include at least the version in the tag message. On the command line this can be done with a command like `git tag -a v1.2.3 -m "1.2.3 some info about this version"`
-9. Push the tag to github with a command like: `git push origin v1.2.3`.
+9. Push the tag to GitHub with a command like: `git push origin v1.2.3`.
 10. Use https://github.com/concord-consortium/starter-projects/releases to make this tag into a GitHub release.
 11. Run the release workflow to update http://starter-projects.concord.org/index.html. 
     1. Navigate to the actions page in GitHub and the click the "Release" workflow. This should take you to this page: https://github.com/concord-consortium/starter-projects/actions/workflows/release.yml. 
     2. Click the "Run workflow" menu button. 
-    3. Type in the tag name you want to release for example `v1.2.3`.  (Note this won't work until the PR has been merged to master)
+    3. Type in the tag name you want to release for example `v1.2.3`.  (Note this won't work until the PR has been merged to main)
     4. Click the `Run Workflow` button.
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@
    - in the GitHub integration section choose the GitHub repo to connect this project to
    - copy the record key, and create a secret in the GitHub repository's settings with the name CYPRESS_RECORD_KEY
    - copy the Project ID and replace the value of `projectId` in cypress.json
+   - To enable extra Cypress to GitHub integration:
+       - go to the settings of the Cypress project
+       - go to the "Integrations" tab
+       - select the GitHub repository
 9. To record code coverage information to codecov.io:
    - go to https://codecov.io/
    - login with your GitHub credentials

--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -9,7 +9,7 @@ Deploying to S3 is handled by the [S3 Deploy Action](https://github.com/concord-
 - **branch builds**: when a developer pushes a branch, GitHub actions will build and deploy it to `starter-projects/branch/[branch-name]/index.html`. If the branch starts or ends with a number this is automatically stripped off and not included in the folder name.
 - **version builds**: when a developer pushes a tag, GitHub actions will build and deploy it to `starter-projects/version/[tag-name]/index.html`
 - **released version path**: the released version of the application is available at `starter-projects/index.html`
-- **master branch**: the master branch build is available at both `starter-projects/index-master.html` and `starter-projects/branch/master/index.html`.  The `index-master.html` form is preferred because it verifies the top level deployment is working for the current code. Additional branches can be added to the top level by updating the `topBranches` configuration in `ci.yml`
+- **main branch**: the main branch build is available at both `starter-projects/index-main.html` and `starter-projects/branch/main/index.html`.  The `index-main.html` form is preferred because it verifies the top level deployment is working for the current code. Additional branches can be added to the top level by updating the `topBranches` configuration in `ci.yml`
 - **staging or other top level paths**: additional top level releases can be added so they are available at `starter-projects/index-[name].html`
 
 ## index-top.html


### PR DESCRIPTION
The upgrade of CodeCov requires a token for every repository.