### PR TITLE
START-1-add-deployment-link-to-jira-2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,6 @@ jobs:
       - build_test
       - cypress
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ github.ref_type == 'branch' && 'development' || 'staging' }}
-      url: https://models-resources.concord.org/starter-projects/${{ steps.s3-deploy.outputs.deployPath }}/index.html
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
[START-1](https://concord-consortium.atlassian.net/browse/START-1)

Uses new version of `s3-deploy-action` to create a GitHub Deployment and set its `logUrl` property which Jira can use to add a deployment link to associated Jira issues.