### PR TITLE
feat: add deployment link to Jira (START-1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
           # skip installing cypress since it isn't needed for just building
           # This decreases the deploy time quite a bit
           CYPRESS_INSTALL_BINARY: 0
-      # change to an actual version once the updated action is released
       - uses: concord-consortium/s3-deploy-action@START-1-add-deployment-link-to-jira
         id: s3-deploy
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,15 @@ jobs:
           # skip installing cypress since it isn't needed for just building
           # This decreases the deploy time quite a bit
           CYPRESS_INSTALL_BINARY: 0
-      - uses: concord-consortium/s3-deploy-action@v1
+      - uses: concord-consortium/s3-deploy-action@START-1-add-deployment-link-to-jira
         id: s3-deploy
         with:
           bucket: models-resources
           prefix: starter-projects
           awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
           awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deployRunUrl: https://models-resources.concord.org/starter-projects/__deployPath__/index.html
           # Parameters to GHActions have to be strings, so a regular yaml array cannot
           # be used. Instead the `|` turns the following lines into a string
           topBranches: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
           # skip installing cypress since it isn't needed for just building
           # This decreases the deploy time quite a bit
           CYPRESS_INSTALL_BINARY: 0
+      # change to an actual version once the updated action is released
       - uses: concord-consortium/s3-deploy-action@START-1-add-deployment-link-to-jira
         id: s3-deploy
         with:


### PR DESCRIPTION
[START-1](https://concord-consortium.atlassian.net/browse/START-1)

Uses new version of `s3-deploy-action` to create a GitHub Deployment and set its `logUrl` property which Jira can use to add a deployment link to associated Jira issues.

[START-1]: https://concord-consortium.atlassian.net/browse/START-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ