### PR TITLE
feat: add deployment link to Jira (START-1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           prefix: starter-projects
           awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
           awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           deployRunUrl: https://models-resources.concord.org/starter-projects/__deployPath__/index.html
           # Parameters to GHActions have to be strings, so a regular yaml array cannot
           # be used. Instead the `|` turns the following lines into a string

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
           # skip installing cypress since it isn't needed for just building
           # This decreases the deploy time quite a bit
           CYPRESS_INSTALL_BINARY: 0
-      # change to an actual version once the updated action is released
       - uses: concord-consortium/s3-deploy-action@START-1-add-deployment-link-to-jira
         id: s3-deploy
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,6 @@ jobs:
       - build_test
       - cypress
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ github.ref_type == 'branch' && 'development' || 'staging' }}
-      url: https://models-resources.concord.org/starter-projects/${{ steps.s3-deploy.outputs.deployPath }}/index.html
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,15 @@ jobs:
           # skip installing cypress since it isn't needed for just building
           # This decreases the deploy time quite a bit
           CYPRESS_INSTALL_BINARY: 0
-      - uses: concord-consortium/s3-deploy-action@v1
+      - uses: concord-consortium/s3-deploy-action@START-1-add-deployment-link-to-jira
         id: s3-deploy
         with:
           bucket: models-resources
           prefix: starter-projects
           awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
           awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deployRunUrl: https://models-resources.concord.org/starter-projects/__deployPath__/index.html
           # Parameters to GHActions have to be strings, so a regular yaml array cannot
           # be used. Instead the `|` turns the following lines into a string
           topBranches: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
           # skip installing cypress since it isn't needed for just building
           # This decreases the deploy time quite a bit
           CYPRESS_INSTALL_BINARY: 0
+      # change to an actual version once the updated action is released
       - uses: concord-consortium/s3-deploy-action@START-1-add-deployment-link-to-jira
         id: s3-deploy
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install Dependencies
         run: npm ci
         env:
-          # skip installing cypress since it isn't needed for just building
+          # Skip installing cypress since it isn't needed for just building
           # This decreases the deploy time quite a bit
           CYPRESS_INSTALL_BINARY: 0
       - uses: concord-consortium/s3-deploy-action@START-1-add-deployment-link-to-jira

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You *do not* need to build to deploy the code, that is automatic.  See more info
 ### Notes
 
 1. Make sure if you are using Visual Studio Code that you use the workspace version of TypeScript.
-   To ensure that you are open a TypeScript file in VSC and then click on the version number next to
+   To ensure that you are, open a TypeScript file in VSC and then click on the version number next to
    `TypeScript React` in the status bar and select 'Use Workspace Version' in the popup menu.
 
 ## Deployment
@@ -121,9 +121,9 @@ To deploy a production release:
 8. Create an annotated tag for the version, of the form `v[x].[y].[z]`, include at least the version in the tag message. On the command line this can be done with a command like `git tag -a v1.2.3 -m "1.2.3 some info about this version"`
 9. Push the tag to GitHub with a command like: `git push origin v1.2.3`.
 10. Use https://github.com/concord-consortium/starter-projects/releases to make this tag into a GitHub release.
-11. Run the release workflow to update http://starter-projects.concord.org/index.html. 
-    1. Navigate to the actions page in GitHub and the click the "Release" workflow. This should take you to this page: https://github.com/concord-consortium/starter-projects/actions/workflows/release.yml. 
-    2. Click the "Run workflow" menu button. 
+11. Run the release workflow to update http://starter-projects.concord.org/index.html.
+    1. Navigate to the actions page in GitHub and the click the "Release" workflow. This should take you to this page: https://github.com/concord-consortium/starter-projects/actions/workflows/release.yml.
+    2. Click the "Run workflow" menu button.
     3. Type in the tag name you want to release for example `v1.2.3`.  (Note this won't work until the PR has been merged to main)
     4. Click the `Run Workflow` button.
 


### PR DESCRIPTION
[START-1](https://concord-consortium.atlassian.net/browse/START-1)

Uses new version of `s3-deploy-action` to create a GitHub Deployment and set its `logUrl` property which Jira can use to add a deployment link to associated Jira issues.

[START-1]: https://concord-consortium.atlassian.net/browse/START-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ