### PR TITLE
Switch release workflow to OIDC auth (DEV-163)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: concord-consortium/s3-deploy-action/deploy-path@v1
         if: always()
         id: s3-deploy-path
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         if: always()
         with:
           role-to-assume: arn:aws:iam::612297603577:role/starter-projects
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/setup-node@v4
       - name: Install Dependencies
         run: npm ci
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::612297603577:role/starter-projects
           aws-region: us-east-1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,15 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/starter-projects
+          aws-region: us-east-1
       - run: >
           aws s3 cp
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ github.event.inputs.version }}/${{ env.SRC_FILE }}
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/${{ env.DEST_FILE }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
     ```
 7. Open your new repository and update all instances of `starter-projects` to `new-repository` and `Starter Projects` to `New Repository`.
 8. Set up S3 deployment by running `./scripts/create-deploy-role.sh new-repository` (requires AWS CLI credentials).
-   This creates the IAM role for OIDC-based deployment and updates `ci.yml` with the correct role ARN.
+   This creates the IAM role for OIDC-based deployment and updates the deploy workflows (`ci.yml`, `release.yml`) with the correct role ARN.
    See [doc/deploy-setup.md](doc/deploy-setup.md) for details.
 9. Delete `doc/deploy-setup.md` and `scripts/create-deploy-role.sh` from your new repo. The canonical versions
    of these files live in `starter-projects` and don't need to be duplicated.

--- a/doc/deploy-setup.md
+++ b/doc/deploy-setup.md
@@ -21,7 +21,7 @@ Run the script from this repo (or from `starter-projects`):
 ./scripts/create-deploy-role.sh <repo-name>
 ```
 
-This creates an IAM role named after the repo, tags it with `RepoName`, attaches the shared S3 deploy policy, scopes the trust policy so only that GitHub repo can assume it, and updates `.github/workflows/ci.yml` with the role ARN.
+This creates an IAM role named after the repo, tags it with `RepoName`, attaches the shared S3 deploy policy, and scopes the trust policy so only that GitHub repo can assume it. When run from inside the target repo, it also updates every workflow file in `.github/workflows/` that references `role-to-assume` with the new role ARN; when run from a different repo's checkout it skips the file edits and just prints the ARN.
 
 ## Note for repos created from starter-projects
 

--- a/scripts/create-deploy-role.sh
+++ b/scripts/create-deploy-role.sh
@@ -60,15 +60,31 @@ aws iam attach-role-policy \
   --role-name "$REPO_NAME" \
   --policy-arn "$POLICY_ARN"
 
-# --- update ci.yml with the role ARN ---
+# --- update workflow files with the role ARN ---
 ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${REPO_NAME}"
-CI_YML=".github/workflows/ci.yml"
-if [ -f "$CI_YML" ]; then
-  sed -i '' "s|role-to-assume: .*|role-to-assume: ${ROLE_ARN}|" "$CI_YML"
-  echo "Updated $CI_YML with role ARN: $ROLE_ARN"
-else
-  echo "Warning: $CI_YML not found. Add this role ARN to your workflow:"
+
+# Only edit workflow files when running inside the target repo. This guards
+# against clobbering another repo's workflows (e.g. running this script from
+# a starter-projects checkout to create a role for a different repo).
+CURRENT_REPO=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
+if [ "$CURRENT_REPO" != "$REPO_NAME" ]; then
+  echo "Skipping workflow file updates: current repo '$CURRENT_REPO' is not '$REPO_NAME'."
+  echo "Add this role ARN to the deploy workflows in $REPO_NAME:"
   echo "  $ROLE_ARN"
+else
+  UPDATED=0
+  for wf in .github/workflows/*.yml .github/workflows/*.yaml; do
+    [ -f "$wf" ] || continue
+    if grep -q "role-to-assume:" "$wf"; then
+      sed -i '' "s|role-to-assume: .*|role-to-assume: ${ROLE_ARN}|" "$wf"
+      echo "Updated $wf with role ARN: $ROLE_ARN"
+      UPDATED=1
+    fi
+  done
+  if [ "$UPDATED" -eq 0 ]; then
+    echo "Warning: no workflow files reference 'role-to-assume:'. Add this role ARN to your workflows:"
+    echo "  $ROLE_ARN"
+  fi
 fi
 
 echo ""


### PR DESCRIPTION
[DEV-163](https://concord-consortium.atlassian.net/browse/DEV-163)

Brings the template's workflows fully onto OIDC and current action versions, mirroring the changes already verified in ocean-explorer:

- **`release.yml`**: switched from static AWS access-key secrets to OIDC — added a  job-level `permissions` block (`id-token: write`, `contents: read`), added an  `aws-actions/configure-aws-credentials@v6` step assuming the existing  `arn:aws:iam::612297603577:role/starter-projects` role, and removed the  `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_DEFAULT_REGION` env vars from the `aws s3 cp` step (region now comes from the credentials step).
- **`ci.yml`**: bumped both `configure-aws-credentials` usages (s3-deploy job and the Playwright report upload) from `@v4` to `@v6`. v4 targets the deprecated Node 20 runtime and warns on every run; v6's only breaking change is the Node 24 runtime — the inputs we use are unchanged.

Also updated `scripts/create-deploy-role.sh` and related docs: the script previously edited only `ci.yml`, which is no longer sufficient now that `release.yml` also references the role ARN. It also edited whatever repo it was run from, so running it from a starter-projects checkout to create a role for another repo would clobber starter-projects' own `ci.yml`. It now updates every workflow file referencing `role-to-assume`, and skips file edits entirely when not run from inside the target repo (printing the ARN to add manually instead). `doc/deploy-setup.md` and the README wording were updated to match. The workflows themselves were already OIDC-first in `doc/deploy.md` and need no further doc changes.

[DEV-163]: https://concord-consortium.atlassian.net/browse/DEV-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ