### PR TITLE
fix(deploy-role): support both OIDC subject claim formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@
     git push -u origin main
     ```
 7. Open your new repository and update all instances of `starter-projects` to `new-repository` and `Starter Projects` to `New Repository`.
-8. Set up S3 deployment by running `./scripts/create-deploy-role.sh new-repository` (requires AWS CLI credentials).
+8. Set up S3 deployment by running `./scripts/create-deploy-role.sh new-repository` (requires AWS CLI credentials
+   and an authenticated `gh` CLI).
    This creates the IAM role for OIDC-based deployment and updates the deploy workflows (`ci.yml`, `release.yml`) with the correct role ARN.
-   See [doc/deploy-setup.md](doc/deploy-setup.md) for details.
+   See [doc/deploy-setup.md](doc/deploy-setup.md) for details — in particular the note on OIDC subject claim
+   formats, which is a common cause of a deploy failing to authenticate.
 9. Delete `doc/deploy-setup.md` and `scripts/create-deploy-role.sh` from your new repo. The canonical versions
    of these files live in `starter-projects` and don't need to be duplicated.
 10. To record code coverage information to codecov.io:

--- a/doc/deploy-setup.md
+++ b/doc/deploy-setup.md
@@ -15,13 +15,75 @@ These only need to be done once per AWS account:
 
 ## Per-repo setup
 
-Run the script from this repo (or from `starter-projects`):
+Requires the **AWS CLI** (with credentials) and the **`gh` CLI** (authenticated). Run the script from this repo (or from `starter-projects`):
 
 ```sh
 ./scripts/create-deploy-role.sh <repo-name>
 ```
 
 This creates an IAM role named after the repo, tags it with `RepoName`, attaches the shared S3 deploy policy, and scopes the trust policy so only that GitHub repo can assume it. When run from inside the target repo, it also updates every workflow file in `.github/workflows/` that references `role-to-assume` with the new role ARN; when run from a different repo's checkout it skips the file edits and just prints the ARN.
+
+Running it against a repo that **already has a role** is safe: it updates that role's trust policy in place rather than failing. That is the migration path for older roles — see below.
+
+## The OIDC subject claim: two formats
+
+**This is easy to get wrong, and the error message points in the wrong direction.**
+
+GitHub has changed the default format of the `sub` claim. Per [the changelog](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/), **every repository created or transferred after 2026-07-15** uses an *immutable* subject claim with the numeric owner and repo IDs embedded, delimited by `@`. Older repositories keep the legacy name-only format unless they explicitly opt in.
+
+```
+legacy:     repo:concord-consortium/my-repo:ref:refs/heads/main
+immutable:  repo:concord-consortium@319219/my-repo@1318683401:ref:refs/heads/main
+```
+
+A trust policy that matches only one format never matches the other, and the assume-role call fails with:
+
+```
+Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity
+```
+
+That reads as a *permissions* problem, so the instinct is to widen the IAM policy. That is the wrong fix — the permissions are fine; the subject string simply does not match.
+
+**The script allows both forms**, each precisely scoped to the one repository, so the role works whichever format GitHub sends and keeps working if an older repo is later opted in. You do not need to know which format your repo uses.
+
+### Diagnosing a mismatch
+
+Ask GitHub what it will actually send:
+
+```sh
+gh api /repos/concord-consortium/<repo-name>/actions/oidc/customization/sub
+```
+
+The `sub_claim_prefix` field is the literal prefix that goes in the token. Compare it against the values in the role's trust policy:
+
+```sh
+aws iam get-role --role-name <repo-name> \
+  --query 'Role.AssumeRolePolicyDocument.Statement[0].Condition.StringLike'
+```
+
+If the prefix matches none of the listed values, that is the bug.
+
+### Migrating an existing role
+
+Roles created before the script allowed both formats carry only the legacy value. They work today, but will break whenever their repo is opted in to immutable claims — and a role created that way for a repo newer than 2026-07-15 never worked at all. To fix, re-run the script:
+
+```sh
+./scripts/create-deploy-role.sh <repo-name>
+```
+
+It detects the existing role and updates the trust policy in place, leaving the tag and attached policies untouched.
+
+## Deploying somewhere other than models-resources
+
+The shared `S3-deploy-by-role-tag` policy grants access **only** to:
+
+```
+arn:aws:s3:::models-resources/${aws:PrincipalTag/RepoName}/*
+```
+
+If your repo deploys anywhere else — `codap-resources`, for instance — the role needs an **additional inline policy** for that bucket. Without one, the role is assumed successfully and then the sync fails with `AccessDenied`, which is its own confusing signal.
+
+Two repos already do this. `story-builder` deploys to both buckets and carries an extra inline policy alongside the managed one; `eepsmedia` deploys *only* to `codap-resources` and so skips the managed policy entirely in favour of a single inline one. See [`docs/iam/README.md` in `concord-consortium/eepsmedia`](https://github.com/concord-consortium/eepsmedia/blob/master/docs/iam/README.md) for a worked example including the policy documents.
 
 ## Note for repos created from starter-projects
 

--- a/doc/deploy-setup.md
+++ b/doc/deploy-setup.md
@@ -71,7 +71,7 @@ Roles created before the script allowed both formats carry only the legacy value
 ./scripts/create-deploy-role.sh <repo-name>
 ```
 
-It detects the existing role and updates the trust policy in place, leaving the `RepoName` tag and any inline policies untouched. It does still run `attach-role-policy`, so re-running also **ensures the shared `S3-deploy-by-role-tag` policy is attached** — harmless and idempotent for a normal repo.
+It detects the existing role and updates the trust policy in place, leaving any inline policies untouched. Re-running also **ensures** the `RepoName` tag is set and the shared `S3-deploy-by-role-tag` policy is attached — both harmless no-ops for a normal repo, and both worth repairing if missing. Without the tag, that policy's `models-resources/${aws:PrincipalTag/RepoName}/*` resolves to `models-resources//*` and grants nothing useful.
 
 > ⚠️ **One exception.** If a role was deliberately built *without* the managed policy — because the repo deploys somewhere other than `models-resources` — re-running the script will attach it. `eepsmedia` is such a role. Either detach it afterwards, or update that role's trust policy directly:
 >

--- a/doc/deploy-setup.md
+++ b/doc/deploy-setup.md
@@ -71,7 +71,14 @@ Roles created before the script allowed both formats carry only the legacy value
 ./scripts/create-deploy-role.sh <repo-name>
 ```
 
-It detects the existing role and updates the trust policy in place, leaving the tag and attached policies untouched.
+It detects the existing role and updates the trust policy in place, leaving the `RepoName` tag and any inline policies untouched. It does still run `attach-role-policy`, so re-running also **ensures the shared `S3-deploy-by-role-tag` policy is attached** — harmless and idempotent for a normal repo.
+
+> ⚠️ **One exception.** If a role was deliberately built *without* the managed policy — because the repo deploys somewhere other than `models-resources` — re-running the script will attach it. `eepsmedia` is such a role. Either detach it afterwards, or update that role's trust policy directly:
+>
+> ```sh
+> aws iam update-assume-role-policy --role-name <repo-name> \
+>   --policy-document file://<trust-policy>.json
+> ```
 
 ## Deploying somewhere other than models-resources
 

--- a/scripts/create-deploy-role.sh
+++ b/scripts/create-deploy-role.sh
@@ -57,9 +57,20 @@ fi
 OWNER_ID="${REPO_JSON%% *}"
 REPO_ID="${REPO_JSON##* }"
 
-case "$OWNER_ID$REPO_ID" in
-  *[!0-9]*|"") echo "Error: unexpected owner/repo IDs from GitHub: '$REPO_JSON'" >&2; exit 1 ;;
-esac
+# Validate each ID separately. Checking the concatenation would let an empty
+# value through whenever the other is numeric, silently producing a malformed
+# subject like repo:org@/name@123:* — a role that can never be assumed.
+for id_pair in "owner:$OWNER_ID" "repo:$REPO_ID"; do
+  id_name="${id_pair%%:*}"
+  id_value="${id_pair#*:}"
+  case "$id_value" in
+    ""|*[!0-9]*)
+      echo "Error: expected a numeric ${id_name} id from GitHub, got '${id_value}'." >&2
+      echo "       Full response: '$REPO_JSON'" >&2
+      exit 1
+      ;;
+  esac
+done
 
 SUB_LEGACY="repo:${GITHUB_ORG}/${REPO_NAME}:*"
 SUB_IMMUTABLE="repo:${GITHUB_ORG}@${OWNER_ID}/${REPO_NAME}@${REPO_ID}:*"
@@ -156,6 +167,7 @@ fi
 echo ""
 echo "Done."
 echo ""
-echo "Note: this role grants access to ${S3_BUCKET} only. If your repo also deploys"
-echo "somewhere else (e.g. codap-resources), it needs an additional inline policy —"
-echo "see doc/deploy-setup.md."
+echo "Note: the attached policy grants access to ${S3_BUCKET} only — it grants nothing"
+echo "on any other bucket. A repo that also deploys elsewhere (e.g. codap-resources)"
+echo "needs an additional inline policy; one that deploys there *instead* needs a"
+echo "replacement policy and does not want this one. See doc/deploy-setup.md."

--- a/scripts/create-deploy-role.sh
+++ b/scripts/create-deploy-role.sh
@@ -16,9 +16,62 @@ fi
 
 REPO_NAME="$1"
 
+# --- check for required tools ---
+command -v aws >/dev/null 2>&1 || { echo "Error: aws CLI not found." >&2; exit 1; }
+command -v gh  >/dev/null 2>&1 || {
+  echo "Error: gh CLI not found. It is needed to look up the repo's numeric IDs" >&2
+  echo "       for the OIDC subject claim. Install it, or see doc/deploy-setup.md" >&2
+  echo "       for how to build the trust policy by hand." >&2
+  exit 1
+}
+
 # --- detect AWS account ID ---
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 echo "AWS Account: $ACCOUNT_ID"
+
+# --- work out the OIDC subject claim(s) to trust ---
+#
+# GitHub issues *immutable* subject claims — with the numeric owner and repo IDs
+# embedded, delimited by @ — for every repository created or transferred after
+# 2026-07-15. Older repositories keep the legacy name-only format unless opted in.
+#
+#   legacy:    repo:concord-consortium/my-repo:ref:refs/heads/main
+#   immutable: repo:concord-consortium@319219/my-repo@1318683401:ref:refs/heads/main
+#
+# A trust policy matching only one format never matches the other, and the failure
+# is misleading: AWS reports "Not authorized to perform sts:AssumeRoleWithWebIdentity",
+# which looks like a permissions problem when it is really a string mismatch.
+#
+# We allow BOTH forms. Each is precisely scoped to this one repository, so the role
+# works whichever format GitHub sends, and keeps working if an older repo is later
+# opted in to immutable claims.
+#
+# See: https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/
+echo "Looking up numeric IDs for $GITHUB_ORG/$REPO_NAME ..."
+if ! REPO_JSON=$(gh api "repos/${GITHUB_ORG}/${REPO_NAME}" --jq '"\(.owner.id) \(.id)"' 2>&1); then
+  echo "Error: could not read repos/${GITHUB_ORG}/${REPO_NAME} via gh." >&2
+  echo "       Check the repo name, and that you are authenticated (gh auth status)." >&2
+  echo "       Details: $REPO_JSON" >&2
+  exit 1
+fi
+OWNER_ID="${REPO_JSON%% *}"
+REPO_ID="${REPO_JSON##* }"
+
+case "$OWNER_ID$REPO_ID" in
+  *[!0-9]*|"") echo "Error: unexpected owner/repo IDs from GitHub: '$REPO_JSON'" >&2; exit 1 ;;
+esac
+
+SUB_LEGACY="repo:${GITHUB_ORG}/${REPO_NAME}:*"
+SUB_IMMUTABLE="repo:${GITHUB_ORG}@${OWNER_ID}/${REPO_NAME}@${REPO_ID}:*"
+echo "  legacy subject:    $SUB_LEGACY"
+echo "  immutable subject: $SUB_IMMUTABLE"
+
+# Report which one GitHub says it will actually send, when that setting is readable.
+# It needs more scope than the public repo endpoint, so failure here is not fatal.
+if ACTUAL_PREFIX=$(gh api "/repos/${GITHUB_ORG}/${REPO_NAME}/actions/oidc/customization/sub" \
+                     --jq '.sub_claim_prefix' 2>/dev/null); then
+  echo "  GitHub reports it will send: ${ACTUAL_PREFIX}:..."
+fi
 
 # --- build the trust policy ---
 TRUST_POLICY=$(cat <<EOF
@@ -36,7 +89,10 @@ TRUST_POLICY=$(cat <<EOF
           "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
         },
         "StringLike": {
-          "token.actions.githubusercontent.com:sub": "repo:${GITHUB_ORG}/${REPO_NAME}:*"
+          "token.actions.githubusercontent.com:sub": [
+            "${SUB_IMMUTABLE}",
+            "${SUB_LEGACY}"
+          ]
         }
       }
     }
@@ -45,13 +101,23 @@ TRUST_POLICY=$(cat <<EOF
 EOF
 )
 
-# --- create the role ---
-echo "Creating IAM role: $REPO_NAME"
-aws iam create-role \
-  --role-name "$REPO_NAME" \
-  --assume-role-policy-document "$TRUST_POLICY" \
-  --tags "Key=RepoName,Value=$REPO_NAME" \
-  --query 'Role.Arn' --output text
+# --- create the role, or update an existing one ---
+# Re-running against an existing role updates its trust policy in place. That is
+# the migration path for roles created before both subject formats were allowed.
+if aws iam get-role --role-name "$REPO_NAME" >/dev/null 2>&1; then
+  echo "Role $REPO_NAME already exists — updating its trust policy"
+  aws iam update-assume-role-policy \
+    --role-name "$REPO_NAME" \
+    --policy-document "$TRUST_POLICY"
+  echo "arn:aws:iam::${ACCOUNT_ID}:role/${REPO_NAME}"
+else
+  echo "Creating IAM role: $REPO_NAME"
+  aws iam create-role \
+    --role-name "$REPO_NAME" \
+    --assume-role-policy-document "$TRUST_POLICY" \
+    --tags "Key=RepoName,Value=$REPO_NAME" \
+    --query 'Role.Arn' --output text
+fi
 
 # --- attach the shared managed policy ---
 POLICY_ARN="arn:aws:iam::${ACCOUNT_ID}:policy/${MANAGED_POLICY_NAME}"
@@ -89,3 +155,7 @@ fi
 
 echo ""
 echo "Done."
+echo ""
+echo "Note: this role grants access to ${S3_BUCKET} only. If your repo also deploys"
+echo "somewhere else (e.g. codap-resources), it needs an additional inline policy —"
+echo "see doc/deploy-setup.md."

--- a/scripts/create-deploy-role.sh
+++ b/scripts/create-deploy-role.sh
@@ -120,6 +120,14 @@ if aws iam get-role --role-name "$REPO_NAME" >/dev/null 2>&1; then
   aws iam update-assume-role-policy \
     --role-name "$REPO_NAME" \
     --policy-document "$TRUST_POLICY"
+  # Ensure the RepoName tag as well. It is set on the create path, so a role made
+  # by an older version of this script has it — but a role created another way may
+  # not, and the shared managed policy resolves
+  # models-resources/${aws:PrincipalTag/RepoName}/*, which without the tag becomes
+  # models-resources//* and grants nothing useful.
+  aws iam tag-role \
+    --role-name "$REPO_NAME" \
+    --tags "Key=RepoName,Value=$REPO_NAME"
   echo "arn:aws:iam::${ACCOUNT_ID}:role/${REPO_NAME}"
 else
   echo "Creating IAM role: $REPO_NAME"


### PR DESCRIPTION
**How we ran into this:** we were setting up S3 deployment for
[`concord-consortium/eepsmedia`](https://github.com/concord-consortium/eepsmedia) — a repo created
on 2026-07-31 by extracting the eepsmedia plugins out of `codap-data-interactives` (CODAP-1423). We
followed `doc/deploy-setup.md`, created the IAM role the documented way, and the first deploy failed
to authenticate. The cause turned out to be in this script rather than in anything specific to that
repo, so it will hit the next new repo in the org the same way. Hence this PR, which is otherwise
outside what we're working on.

The short version: `create-deploy-role.sh` hardcodes the **legacy** OIDC subject claim, so it
produces a role that **cannot be assumed at all** by any repository created or transferred after
2026-07-15.

## The problem

GitHub now issues *immutable* subject claims — numeric owner and repo IDs embedded, delimited by
`@` — for every repo created or transferred after **2026-07-15**
([changelog](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/)).
Older repos keep the legacy name-only format unless explicitly opted in.

```
legacy:     repo:concord-consortium/my-repo:ref:refs/heads/main
immutable:  repo:concord-consortium@319219/my-repo@1318683401:ref:refs/heads/main
```

A policy matching one format never matches the other. **The failure is actively misleading:**

```
Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity
```

That reads as a permissions problem, so the natural response is to widen the IAM policy — which is
the wrong fix. The permissions were correct all along; the subject string simply didn't match.

Worth noting how easy it is to walk into. The eepsmedia role was built by copying `story-builder`'s
trust policy and verifying it byte-identical — which felt like a virtue and was in fact the bug,
because `story-builder` is a 2020 repo on the legacy format. **Matching a working precedent is only
safe when the precedent is subject to the same rules.**

## The fix

**Allow both forms rather than choosing between them**, since this script serves existing repos as
well as new ones. Each entry is precisely scoped to a single repository, so allowing both costs no
meaningful privilege — and a role keeps working if an older repo is later opted in to immutable
claims, with no follow-up needed.

Verified against what GitHub reports it will actually send:

| Repo | Created | Sends | Covered |
|---|---|---|---|
| `eepsmedia` | 2026-07-31 | immutable | ✅ |
| `story-builder` | 2020-11-18 | legacy | ✅ |
| `starter-projects` | 2018 | legacy | ✅ |

## Also in this PR

- **The script is now safe to re-run.** Against a repo that already has a role it updates the trust
  policy in place instead of failing with `EntityAlreadyExists`. **This is the migration path for
  existing roles** — 27 of the 28 OIDC roles in the account carry only the legacy subject today
  (`eepsmedia` is the exception, fixed by hand), and each will break the moment its repo is opted in.

  Re-running rewrites the trust policy, and ensures both the `RepoName` tag and the managed policy
  are in place. Tags were previously applied only on the create path, which left a gap in the very
  migration path this PR recommends — that is now fixed, since the tag is load-bearing: the managed
  policy grants `models-resources/${aws:PrincipalTag/RepoName}/*`, which without it resolves to
  `models-resources//*` and grants nothing useful, while the role still assumes successfully so the
  failure surfaces later as `AccessDenied`.

  Still not strictly idempotent, and worth saying so rather than overclaiming: re-running attaches
  the managed policy, which is a real state change for a role deliberately built without it (see the
  warning in `deploy-setup.md`).
- **`gh` CLI is now required**, to look up the numeric IDs. Checked explicitly up front with a
  useful error rather than failing obscurely later.
- **Docs**: the two formats, how to diagnose a mismatch via the `sub_claim_prefix` endpoint, and how
  to migrate an existing role.
- **Documented a second, unrelated trap**: the shared `S3-deploy-by-role-tag` policy grants access to
  `models-resources` **only** — nothing on any other bucket. A repo deploying somewhere else *as
  well* needs an additional inline policy; one deploying there *instead* needs a replacement and does
  not want the managed policy at all. That failure is confusing in its own way — the role is assumed
  *successfully*, and only then does the sync fail with `AccessDenied`. `story-builder` is the first
  case, `eepsmedia` the second.

## Diagnosing this in future

```sh
gh api /repos/concord-consortium/<repo-name>/actions/oidc/customization/sub
```

`sub_claim_prefix` is the literal prefix GitHub puts in the token. Compare it against the trust
policy's `StringLike` values; if it matches none of them, that's the bug.

## Notes for review

- Rebased onto current `main` — an earlier draft was based on `3eafd3d` and would have reverted
  `e6842e8` (the multi-workflow update and the guard against editing another repo's workflows).
  Confirmed the diff against `origin/main` removes nothing from that change.
- I have **not** re-run the script against existing roles. 27 of the 28 OIDC roles in the account
  carry only the legacy subject and would benefit from a re-run, but sweeping them is a deliberate
  follow-up rather than something to bundle into a script fix.
- **Copilot review addressed** (3 comments, all valid, all fixed): a validation bug where an empty
  owner or repo ID slipped through and produced a malformed subject; the `models-resources` wording
  above; and a doc claim that re-running left attached policies untouched when the script always
  re-attaches. Following that last one up surfaced a footgun now documented — re-running against a
  role deliberately built *without* the managed policy will attach it, so those roles should have
  their trust policy updated directly instead.

