### PR TITLE
build: drop a permission the release job does not use

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
     steps:
       - uses: aws-actions/configure-aws-credentials@v6
         with:


### PR DESCRIPTION
Drops `contents: read` from `release.yml`'s permissions block, leaving `id-token: write` alone.

## How this came up

Not from reading the docs. Copilot flagged it while reviewing
[concord-consortium/sampler#142](https://github.com/concord-consortium/sampler/pull/142), the PR that
moved sampler's deploys onto OIDC — and sampler's `release.yml` was copied from this repo, so its
observation applies here too.

Its point was simply that the release job never checks out the repository and makes no repo-scoped
API call, so `contents: read` grants it nothing. That is correct, and it also caught an inconsistency
in that PR's own description, which claimed the permission set was "the minimum each job needs" while
carrying a scope nothing used.

Rather than leave sampler quietly tighter than the template it came from, this propagates the change
back to the source.

## Why it is safe

The job has exactly two steps: `aws-actions/configure-aws-credentials`, and one `aws s3 cp`. There is
no `actions/checkout`. Downloading a public marketplace action does not consume `GITHUB_TOKEN`
permissions, so removing the scope does not affect the credentials step.

This is not a reading of the documentation. The tightened configuration has since run against
production in sampler: dispatching its `Release` workflow with `v1.0.4` succeeded with
`id-token: write` alone —

```
role-to-assume: arn:aws:iam::612297603577:role/sampler
Assuming role with OIDC
Authenticated as assumedRoleId AROAY...:GitHubActions
```

— and the copied object was byte-identical to what was already live, so the run exercised the whole
credential path without changing anything.

`ci.yml` is deliberately untouched. Its `s3-deploy` job does run `actions/checkout`, so it keeps
`contents: read`, and the Playwright job keeps its own block.

## Worth knowing

Naming a `permissions` block sets every scope not listed to `none`, so this narrows rather than
widens. On a public repository the practical difference is nil — `contents: read` grants read access
to content that is already world-readable — so the value here is that the block now says what the job
actually needs, which is the point of writing one at all.

`ocean-explorer` carries the same pair in its `release.yml` and could take the same change; not done
here to keep this to the template.
